### PR TITLE
Run camera streamer code as a systemd service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ venv
 
 *data/
 certs/
+scripts/smart-sec-cam.service

--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ Example 2: 2 cameras  with hostnames `camera1.local` and `camera2.local`, with t
 ### Setting up the server
 
 #### Docker:
-0. Install Docker following [the instructions on their website](https://docs.docker.com/engine/install/ubuntu/).
-1. Clone this repository
-2. Generate SSL certificates: `./create-certs.sh`. Alternatively, you may place your own certs in the `certs` dir
-3. Build and run the docker containers: `API_URL=<server-hostname:server-port> docker-compose up -d --build`. 
+1. Install Docker following [the instructions on their website](https://docs.docker.com/engine/install/ubuntu/).
+2. Clone this repository
+3. Generate SSL certificates: `./create-certs.sh`. Alternatively, you may place your own certs in the `certs` dir
+4. Build and run the docker containers: `API_URL=<server-hostname:server-port> docker-compose up -d --build`. 
 For example, if the server was running on the host `sec-cam-server` and port `8443` (the default), you should use 
 `API_URL=sec-cam-server:8443`.
-4. You should now be able to view the UI at `https://<server-hostname>:8443`.
-5. Until a user is created, you will be automatically redirected to
+5. You should now be able to view the UI at `https://<server-hostname>:8443`.
+6. Until a user is created, you will be automatically redirected to
 
 
 #### Configuration:
@@ -84,9 +84,12 @@ When you're done adding users, you should re-set this value to `0` and restart t
 
 NOTE: These instructions assume you are deploying to a Debian-based OS.
 
-0. Install the `python3-opencv` package and dependencies: `sudo apt-get install python3-opencv libatlas-base-dev`
-1. Clone this repository
-2. Install the package: `cd backend && python3 -m pip install .[streamer]`. If you are using the Raspberry Pi camera
+1. Install the `python3-opencv` package and dependencies: `sudo apt-get install python3-opencv libatlas-base-dev`
+2. Clone this repository
+3. Install the package: `cd backend && python3 -m pip install .[streamer]`. If you are using the Raspberry Pi camera
 module, run `cd backend && python3 -m pip install .[streamer,picam]`.
-3. Update `--server_url` in `run.sh` to point at the host you deployed the server to.
-4. In the Web UI, you should see live video from that camera.
+4. Update `--server_url` in `run.sh` to point at the host you deployed the server to.
+5. You can install the camera software as a systemd service or run it manually. Either:
+   1. Run the script to create the camera systemd service: `cd scripts && ./create-streamer-service.sh`
+   2. Run the camera manually: `./run.sh`.
+6. In the Web UI, you should see live video from that camera.

--- a/backend/smart_sec_cam/streamer/run.sh
+++ b/backend/smart_sec_cam/streamer/run.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
+
 sudo iwconfig wlan0 power off
 python3 streamer.py --redis-url sec-cam-server

--- a/scripts/create-streamer-service.sh
+++ b/scripts/create-streamer-service.sh
@@ -8,8 +8,8 @@ sed -i "/^User=/ s/$/$USER\n/" smart-sec-cam.service
 # Use current path to set execution path for service file
 echo "Setting execution path for streamer service..."
 path=$(cd ../ && pwd)
-echo "ExecStart=$path/smart_sec_cam/streamer/run.sh" >> smart-sec-cam.service
-echo "WorkingDirectory=$path/smart_sec_cam/streamer/" >> smart-sec-cam.service
+echo "ExecStart=$path/backend/smart_sec_cam/streamer/run.sh" >> smart-sec-cam.service
+echo "WorkingDirectory=$path/backend/smart_sec_cam/streamer/" >> smart-sec-cam.service
 # Copy service file to systemd directory
 echo "Copying service file to systemd service directory..."
 sudo cp smart-sec-cam.service /etc/systemd/system/

--- a/scripts/create-streamer-service.sh
+++ b/scripts/create-streamer-service.sh
@@ -9,7 +9,7 @@ sed -i "/^User=/ s/$/$USER\n/" smart-sec-cam.service
 echo "Setting execution path for streamer service..."
 path=$(cd ../ && pwd)
 echo "ExecStart=$path/smart_sec_cam/streamer/run.sh" >> smart-sec-cam.service
-echo "WorkingDirectory=$path/" >> smart-sec-cam.service
+echo "WorkingDirectory=$path/smart_sec_cam/streamer/" >> smart-sec-cam.service
 # Copy service file to systemd directory
 echo "Copying service file to systemd service directory..."
 sudo cp smart-sec-cam.service /etc/systemd/system/

--- a/scripts/create-streamer-service.sh
+++ b/scripts/create-streamer-service.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copy base file to the actual file
+cp smart-sec-cam.base.service smart-sec-cam.service
+# Set current user as user to run service as
+echo "Setting user $USER as streamer service user..."
+sed -i "/^User=/ s/$/$USER\n/" smart-sec-cam.service
+# Use current path to set execution path for service file
+echo "Setting execution path for streamer service..."
+path=$(cd ../ && pwd)
+echo "ExecStart=$path/smart_sec_cam/streamer/run.sh" >> smart-sec-cam.service
+echo "WorkingDirectory=$path/" >> smart-sec-cam.service
+# Copy service file to systemd directory
+echo "Copying service file to systemd service directory..."
+sudo cp smart-sec-cam.service /etc/systemd/system/
+# Enable and start service
+echo "Enabling and starting service..."
+sudo systemctl enable smart-sec-cam
+sudo systemctl start smart-sec-cam
+echo "Done!"

--- a/scripts/smart-sec-cam.base.service
+++ b/scripts/smart-sec-cam.base.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Smart Sec Cam Streamer Service
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=10
+User=


### PR DESCRIPTION
- Adds a base `.service` file for running streamer as a systemd service.
- Adds `create-streamer-service.sh` to configure `.service` file for per-system installation.
- Updates README.md with instructions on how to install streamer service under systemd.