### PR TITLE
Replace Blob-based image conversion with Base64 conversion

### DIFF
--- a/backend/setup.cfg
+++ b/backend/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = smart-sec-cam
-version = 0.3.2
+version = 0.3.6
 author = Scott Barnes
 author_email = sgbarnes@protonmail.com
 description = A privacy-focused intelligent security camera system

--- a/frontend/smart-sec-cam/package-lock.json
+++ b/frontend/smart-sec-cam/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-sec-cam",
-  "version": "0.3.2",
+  "version": "0.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/frontend/smart-sec-cam/package.json
+++ b/frontend/smart-sec-cam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-sec-cam",
-  "version": "0.3.2",
+  "version": "0.3.6",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.8.2",

--- a/frontend/smart-sec-cam/src/components/ImageViewer.js
+++ b/frontend/smart-sec-cam/src/components/ImageViewer.js
@@ -10,20 +10,15 @@ let socket = io(SERVER_URL)
 
 export default function ImageViewer(props) {
     const [srcBlob, setSrcBlob] = React.useState(null);
-    const [oldUrl, setOldUrl] = React.useState(null);
     const [cookies, setCookie] = useCookies(["token"]);
 
 
     React.useEffect(() => {
         socket.on('image', (payload) => {
             if (payload.room === props.room){
-                var image = new Blob( [ new Uint8Array( payload.data ) ], { type: "image/jpeg" } )
-                setOldUrl(srcBlob);
-                setSrcBlob(URL.createObjectURL( image ));
-                if (oldUrl != null){
-                    URL.revokeObjectURL(oldUrl)
-                }
-                image = null;
+                const data = new Uint8Array(payload.data);
+                const dataBase64 = btoa(String.fromCharCode.apply(null, data));
+                setSrcBlob(dataBase64);
             }
         });
         socket.emit('join', {"room": props.room, "token": cookies.token});
@@ -31,7 +26,7 @@ export default function ImageViewer(props) {
 
     return (
         <div className="imageviewer">
-            <img src={srcBlob} alt={props.room} ></img>
+            <img src={`data:image/jpeg;base64,${srcBlob}`} alt={props.room} ></img>
         </div>
     );
 


### PR DESCRIPTION
This change fixes a memory issue in the UI caused by the use of `new Blob` on a high quantity of images without GC kicking in.

Closes #46 