### PR TITLE
Fix Greenlet Error

### DIFF
--- a/backend/smart_sec_cam/redis/image_receiver.py
+++ b/backend/smart_sec_cam/redis/image_receiver.py
@@ -1,22 +1,17 @@
-import queue
-import threading
-import time
-from typing import List, Dict
+# image_receiver.py
 
 import redis
+from typing import List, Dict
 
 
 class RedisImageReceiver:
-    listener_sleep_time = 0.01
-
     def __init__(self, redis_host: str = "localhost", redis_port: int = 6379):
         self.redis_host = redis_host
         self.redis_port = redis_port
-        self.message_queue = queue.Queue()
         self.subscribed_channels = []
         self.r_conn = redis.StrictRedis(host=self.redis_host, port=self.redis_port)
         self.pubsub = self.r_conn.pubsub()
-        self.listener_thread = None
+        self._subscribe()
 
     def set_channels(self, channels: List[str]):
         self.subscribed_channels = channels
@@ -24,43 +19,26 @@ class RedisImageReceiver:
 
     def add_channel(self, channel: str):
         if channel in self.subscribed_channels:
-            raise ValueError("Channel " + str(channel) + " is already in the subscribed channel list")
+            raise ValueError(f"Channel {channel} is already in the subscribed channel list")
         self.subscribed_channels.append(channel)
         self._subscribe()
 
     def remove_channel(self, channel: str):
-        self.subscribed_channels.remove(channel)
-        self._subscribe()
+        if channel in self.subscribed_channels:
+            self.subscribed_channels.remove(channel)
+            self._subscribe()
 
     def get_all_channels(self) -> List[str]:
         return [key.decode("utf-8") for key in self.r_conn.keys()]
 
-    def has_message(self) -> bool:
-        return not self.message_queue.empty()
-
-    def get_message(self) -> Dict[str, any]:
-        return self.message_queue.get()
-
-    def start_listener_thread(self):
-        listener_thread = threading.Thread(target=self._listen_for_messages)
-        listener_thread.start()
+    def get_new_message(self):
+        try:
+            return self.pubsub.get_message(ignore_subscribe_messages=True)
+        except (redis.exceptions.RedisError, RuntimeError) as e:
+            print(f"Redis error: {e}")
+            return None
 
     def _subscribe(self):
         if self.subscribed_channels:
+            self.pubsub.unsubscribe()
             self.pubsub.subscribe(*self.subscribed_channels)
-
-    def _redis_message_handler(self, message: any):
-        self.message_queue.put(message)
-
-    def _get_new_pubsub_message(self):
-        try:
-            new_message = self.pubsub.get_message(ignore_subscribe_messages=True)
-            if new_message:
-                self.message_queue.put(new_message)
-        except (redis.exceptions.RedisError, RuntimeError) as e:
-            print(e)
-
-    def _listen_for_messages(self):
-        while True:
-            self._get_new_pubsub_message()
-            time.sleep(0.01)

--- a/backend/smart_sec_cam/redis/image_receiver.py
+++ b/backend/smart_sec_cam/redis/image_receiver.py
@@ -1,8 +1,6 @@
-# image_receiver.py
-
-import redis
 from typing import List, Dict
 
+import redis
 
 class RedisImageReceiver:
     def __init__(self, redis_host: str = "localhost", redis_port: int = 6379):


### PR DESCRIPTION
The following greenlet error was found preceding the SocketIO protocol errors:

```
Second simultaneous read on fileno 7 detected.  Unless you really know what you're doing, make sure that only one greenthread can read any particular socket.  Consider using a pools.Pool. If you do know what you're doing and want to disable this error, call eventlet.debug.hub_prevent_multiple_readers(False) - MY THREAD=<built-in method switch of greenlet.greenlet object at 0x7f054f8e0b80>; THAT THREAD=FdListener('read', 7, <built-in method switch of greenlet.greenlet object at 0x7f054f8e0740>, <built-in method throw of greenlet.greenlet object at 0x7f054f8e0740>)  
```