### PR TITLE
fix: resolve numpy/opencv dependency conflict in streamer extras

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A privacy-focused intelligent security camera system"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 dependencies = [
     "redis >= 4.0.2",
 ]
@@ -28,11 +28,11 @@ where = ["."]
 
 [project.optional-dependencies]
 streamer = [
-    "opencv-python-headless >= 4.5.5",
-    "numpy == 1.24.2"
+    "opencv-python-headless >= 4.5.5, < 5",
+    "numpy >= 1.24.2"
 ]
 detector = [
-    "opencv-python-headless >= 4.5.5",
+    "opencv-python-headless >= 4.5.5, < 5",
     "numpy >= 1.22.0",
     "imutils >= 0.5.4"
 ]
@@ -41,6 +41,6 @@ server = [
     "flask-cors ~= 3.0.10",
     "flask-socketio ~= 5.1.0",
     "eventlet ~= 0.40.0",
-    "opencv-python-headless >= 4.5.5",
+    "opencv-python-headless >= 4.5.5, < 5",
     "pyjwt >= 2.4.0"
 ]


### PR DESCRIPTION
## Problem

`pip install smart-sec-cam[streamer]` fails because:

- `opencv-python-headless >= 4.10` requires `numpy >= 2` (for Python >= 3.9)
- `streamer` extras pins `numpy == 1.24.2` (numpy 1.x)
- These constraints are incompatible

```
ERROR: opencv-python-headless 4.12.0.88 requires numpy<2.3.0,>=2; python_version >= "3.9", but you have numpy 1.24.2 which is incompatible.
```

Fixes #69

## Fix

Three changes in `backend/pyproject.toml`:

1. **Relax numpy pin**: `numpy == 1.24.2` -> `numpy >= 1.24.2`
   - Allows pip to resolve a numpy version compatible with both opencv and picamera2
   
2. **Bump requires-python**: `>= 3.7` -> `>= 3.9`
   - numpy 2.x requires Python 3.9+
   - opencv-python-headless 4.10+ requires numpy 2.x on Python 3.9+
   - Python 3.7 and 3.8 are EOL anyway

3. **Add opencv upper bound**: `opencv-python-headless >= 4.5.5` -> `>= 4.5.5, < 5`
   - Prevents future major version breaks

## Note for Raspberry Pi users

If picamera2's simplejpeg was compiled against numpy 1.x, you may see a binary incompatibility error after upgrading. Fix with:

    sudo apt update && sudo apt upgrade python3-picamera2
